### PR TITLE
Support for all Trino auth mechanisms

### DIFF
--- a/fugue_trino/_constants.py
+++ b/fugue_trino/_constants.py
@@ -7,6 +7,7 @@ FUGUE_TRINO_CONF_HOST = "fugue.trino.host"
 FUGUE_TRINO_CONF_PORT = "fugue.trino.port"
 FUGUE_TRINO_CONF_USER = "fugue.trino.user"
 FUGUE_TRINO_CONF_PASSWORD = "fugue.trino.password"
+FUGUE_TRINO_CONF_AUTH = "fugue.trino.auth"
 
 FUGUE_TRINO_ENV_PASSWORD = "FUGUE_TRINO_PASSWORD"
 


### PR DESCRIPTION
Any chance fugue_trino could support the other authentication mechanisms trino-python-client provides (https://github.com/trinodb/trino-python-client/blob/47bbdd8d1cfd1b5dc0dea0fe9e915aeff769639d/README.md#authentication-mechanisms)? For example, in our environment we provide a custom class that is a subclass of trino.auth.JWTAuthentication for auth. This PR is a quick proof of concept that allows fugue_trino to use authentication methods beyond BasicAuthentication.

Cheers